### PR TITLE
Frontend files symlink

### DIFF
--- a/lib/capistrano/forkcms/defaults.rb
+++ b/lib/capistrano/forkcms/defaults.rb
@@ -16,6 +16,7 @@ namespace :deploy do
   after :starting, 'composer:install_executable'
   after :starting, 'cachetool:install_executable'
   after :publishing, 'forkcms:symlink:document_root'
+  after :publishing, 'forkcms:symlink:frontend_files'
   after :publishing, 'forkcms:opcache:reset'
   after :updated, 'forkcms:migrations:execute'
   before :reverted, 'forkcms:migrations:rollback'

--- a/lib/capistrano/forkcms/defaults.rb
+++ b/lib/capistrano/forkcms/defaults.rb
@@ -2,7 +2,7 @@
 set :linked_files, []
 set :linked_files,  %w(app/config/parameters.yml)
 set :linked_dirs, []
-set :linked_dirs, %w(app/logs app/sessions src/Frontend/Files)
+set :linked_dirs, %w(app/logs app/sessions)
 
 # Run required tasks after the stage
 Capistrano::DSL.stages.each do |stage|

--- a/lib/capistrano/tasks/symlink.rake
+++ b/lib/capistrano/tasks/symlink.rake
@@ -18,5 +18,31 @@ namespace :forkcms do
         end
       end
     end
+    desc <<-DESC
+      Links the frontend files folders to their shared counterparts. 
+      It copies the contents of the git folders to the shared folder so you can add files through git.
+    DESC
+    task :frontend_files do
+      on roles(:web) do
+        # get the list of folders in the frontend files
+        folders = get_frontend_files_folders()
+
+        # loop the folders
+        folders.each do |folder|
+          # create the shared folder if it doesn't exist
+          execute :mkdir, '-p', "#{shared_path}/files/#{folder}"
+          # copy the contents of the release folder to the shared folder, allowing for adding new files through git
+          execute :cp, '-r', "#{release_path}/src/Frontend/Files/#{folder}", "#{shared_path}/files/"
+          # remove them from the release folder
+          execute :rm, '-rf', "#{release_path}/src/Frontend/Files/#{folder}"
+          # create a symlink to the shared folder
+          execute :ln, '-s', "#{shared_path}/files/#{folder}", "#{release_path}/src/Frontend/Files/#{folder}"
+        end
+      end
+    end
+
+    def get_frontend_files_folders
+      return capture("if [ -e #{release_path}/src/Frontend/Files ]; then ls -1 #{release_path}/src/Frontend/Files; fi").split(/\r?\n/)
+    end
   end
 end


### PR DESCRIPTION
Create symlinks for the shared frontend file folders
-

Previously, when deploying, the release's frontend files got deleted and replaced by a symlink to the shared files. Because of this it was impossible to add new folders to git, deploy and have them automatically present in the shared folder.

Because this is Capistrano 3's default behaviour I decided to replace it with a task of our own.
This copies the contents of the folders to the shared folder before deleting and symlinking them, much like it was in Capistrano 2.