### PR TITLE
Execute console commands in a production environment

### DIFF
--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -43,7 +43,7 @@ namespace :forkcms do
 
             # Update the locale through the console command
             if filename.index('locale.xml') != nil
-              execute :php, "#{release_path}/bin/console forkcms:locale:import -f #{migration_path}/#{filename}"
+              execute :php, "#{release_path}/bin/console forkcms:locale:import -f #{migration_path}/#{filename} --env=prod"
 
               next
             end


### PR DESCRIPTION
When deploying we should always assume the server isn't a development server